### PR TITLE
bug-fix 15:numero de colunas aumentado, os elementos ficam fora da caixa

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -298,6 +298,9 @@ input[type="submit"]:disabled {
     border-radius: 8px;
     border: 2px solid var(--border-color);
     transition: border-color 0.3s ease;
+    gap: 16px;
+    max-height: 400px; 
+    overflow-y: auto;
 }
 
 .matrix-input:focus-within {
@@ -323,6 +326,7 @@ input[type="submit"]:disabled {
     margin-top: 0;
     padding: 0.5rem;
     text-align: center;
+    max-width: 100px;
 }
 
 /* Result Styles */


### PR DESCRIPTION
## Descrição
Ao adicionar mais colunas as caixas de input passam a scroll.

## 🔗 Issue Relacionada
Closes #15 

## Tipo de Mudança
- [ ] Nova funcionalidade (non-breaking change)
- [x] Correção de bug (non-breaking change)
- [ ] Refatoração (mudança que não corrige bug nem adiciona funcionalidade)
- [ ] Documentação
- [ ] Limpeza de código
- [ ] Performance
- [ ] Testes
- [ ] Configuração/Setup

## O Que Foi Feito?
Modificar CSS

## Screenshots/Evidências
<img width="1440" height="713" alt="image" src="https://github.com/user-attachments/assets/2082fff8-2a9c-4fc9-a168-2ba162c19e23" />


## Notas Adicionais
Nenhuma