### PR TITLE
[fix]: validar encrypt message

### DIFF
--- a/static/js/encrypt.js
+++ b/static/js/encrypt.js
@@ -30,7 +30,7 @@ form.addEventListener('submit', async function(e) {
   try {
     const detResult = await apiCall('/determinant', payload_determinant);
     if (detResult.result === 0) {
-      showError('A matriz de codificação deve ser invertível (determinante diferente de zero).');
+      showError('A matriz de codificação deve ser invertível (det ≠ 0).');
       return;
     }
     const result = await apiCall('/encrypt', payload);


### PR DESCRIPTION
## Descrição
Antes de encriptar a mensagem, avisa ao user que meteu uma matriz singular

## 🔗 Issue Relacionada
Closes #54 

## Tipo de Mudança
- [ ] Nova funcionalidade (non-breaking change)
- [x] Correção de bug (non-breaking change)
- [ ] Refatoração (mudança que não corrige bug nem adiciona funcionalidade)
- [ ] Documentação
- [ ] Limpeza de código
- [ ] Performance
- [ ] Testes
- [ ] Configuração/Setup

## O Que Foi Feito?

- Adicionar `payload_determinant` no `encrypt.js`
- Chamar API `/determinant` e verificar se retorna 0

## Screenshots/Evidências
<img width="965" height="748" alt="image" src="https://github.com/user-attachments/assets/f42777f2-032c-498d-842d-0580a3c1004b" />